### PR TITLE
remove Open Collective Post Install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "jest": "^24.1.0",
     "jest-puppeteer": "^4.0.0",
     "node-sass": "^4.9.0",
-    "opencollective-postinstall": "^2.0.2",
-    "opencollective": "^1.0.3",
     "prettier": "^1.16.4",
     "prettier-check": "^2.0.0",
     "puppeteer": "^1.13.0",
@@ -36,8 +34,7 @@
     "build:js": "rollup -c",
     "prepublish": "yarn run build",
     "travis-deploy-once": "travis-deploy-once",
-    "semantic-release": "semantic-release",
-    "postinstall": "opencollective-postinstall"
+    "semantic-release": "semantic-release"
   },
   "dependencies": {
     "document-register-element": "^1.8.1"
@@ -45,10 +42,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/ColinEberhardt/applause-button.git"
-  },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/applause-button"
   },
   "jest": {
     "preset": "jest-puppeteer"


### PR DESCRIPTION
remove Open Collective Post Install - the project still can use Open Collective, but there should be no post install script running.