### PR TITLE
chore: Read version from package.json via rollup plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "applause-button",
   "description": "A zero-configuration button for adding applause / claps / kudos to web pages and blog-posts",
-  "version": "0.0.0-development",
+  "version": "3.4.0",
   "main": "dist/applause-button.js",
   "type": "module",
   "license": "MIT",
@@ -12,6 +12,7 @@
     "@jest/globals": "^29.7.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-terser": "^0.4.4",
     "chokidar-cli": "^3.0.0",
     "jest": "^29.7.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,18 @@
 import babel from "@rollup/plugin-babel";
 import resolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
 import terser from "@rollup/plugin-terser";
 
 export default {
   input: "src/applause-button.js",
   plugins: [
     resolve(),
+    replace({
+      values: {
+        '__VERSION': process.env.npm_package_version,
+      },
+      preventAssignment: true,
+    }),
     babel({
       presets: [
         [

--- a/src/applause-button.js
+++ b/src/applause-button.js
@@ -1,6 +1,7 @@
 import "@ungap/custom-elements";
 
-const VERSION = "3.3.0";
+// Rollup will replace __VERSION with actual package version:
+const VERSION = "__VERSION";
 const API = "https://api.applause-button.com";
 
 const getClaps = (api, url) =>

--- a/src/applause-button.test.js
+++ b/src/applause-button.test.js
@@ -28,7 +28,7 @@ expect.extend({
   toHaveClass,
 });
 
-const VERSION = "3.3.0";
+const VERSION = process.env.npm_package_version;
 const BASE_URL = "https://api.applause-button.com";
 let serverClapCount;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,7 +1269,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -1635,6 +1635,14 @@
     is-builtin-module "^3.2.1"
     is-module "^1.0.0"
     resolve "^1.22.1"
+
+"@rollup/plugin-replace@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.7.tgz#150c9ee9db8031d9e4580a61a0edeaaed3d37687"
+  integrity sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
 
 "@rollup/plugin-terser@^0.4.4":
   version "0.4.4"
@@ -5091,6 +5099,13 @@ lru-cache@^7.14.1:
   version "7.18.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+magic-string@^0.30.3:
+  version "0.30.11"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.11.tgz#301a6f93b3e8c2cb13ac1a7a673492c0dfd12954"
+  integrity sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
This one is quite simple: use a rollup plugin to set the correct version from `package.json` into the component code.

Note that the version currently in the javascript is 3.3.0, yet our latest release is actually 3.4.0, which neatly highlights the problem this PR addresses - people are fallible 🤭 

FYI @ColinEberhardt - I hope this is what you meant!

Resolves #26 