### PR TITLE
fix: Prevent release workflow on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: Release master
     runs-on: ubuntu-latest
+    if: github.repository == 'ColinEberhardt/applause-button'
     permissions:
       contents: write # to publish a GitHub release
       issues: write # to comment on released issues

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Navigate to http://localhost:8081 to view the test page; remember to refresh the
 
 All releases are created automatically via
 [semantic release](https://github.com/semantic-release/semantic-release)
-running on Travis.
+running as a GitHub workflow.
 
 ## Contributors
 


### PR DESCRIPTION
Our new github workflow tried to run a release from my fork once I'd synchronized with upstream... Whoops!

It's not critical as the workflow fails on forks, due to not having access to the tokens it needs, but still, it's an easy fix and prevents confusion.