### PR TITLE
fix: Include docs commits in patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,18 @@
   "engines": {
     "node": ">=18.17.0"
   },
+  "release": {
+    "plugins": [
+      ["@semantic-release/commit-analyzer", {
+        "releaseRules": [
+          { "type": "docs", "release": "patch" }
+        ]
+      }],
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ]
+  },
   "publishConfig": {
     "provenance": true
   },


### PR DESCRIPTION
There is a chance that the README on our npm page becomes out of sync with the GitHub repo, therefore I have decided to include `docs` commits in the patch release group.

Note that we are unlikely to push many `docs` commits, as we have a single README,  so we are unlikely to see false positives.