### PR TITLE
Change referrerPolicy

### DIFF
--- a/src/applause-button.js
+++ b/src/applause-button.js
@@ -20,6 +20,7 @@ const updateClaps = (api, claps, url) =>
     headers: {
       "Content-Type": "text/plain", //avoids preflight request
     },
+    referrerPolicy: "no-referrer-when-downgrade", // send the full referrer to the applause server, to have by default a clap per page 
     body: JSON.stringify(`${claps},${VERSION}`),
   })
     .then((response) => response.text())


### PR DESCRIPTION
I see that for many websites using the applause-button, the clap count is shared between all the pages.

People can pass a specific url parameter to have individual claps per page, but by default they get a single counter for their website, shared across all pages.

Reading the fetch doc, I see we can change that behavior by setting a different  `referrerPolicy`.

`no-referrer-when-downgrade` seems to be what we are looking for. See that [page](https://javascript.info/fetch-api) for more details. With that option, the full page URL should be sent to the applause server for each clap, allowing the server to attribute the clap to that specific page.

What's your opinion on this?

PS : see that [blog](https://blog.rotaractmora.org/dear-southern-coastal-line/) as an exemple of badly handled clap count