### PR TITLE
Correction: remove referer policy

### DIFF
--- a/src/applause-button.js
+++ b/src/applause-button.js
@@ -20,7 +20,6 @@ const updateClaps = (api, claps, url) =>
     headers: {
       "Content-Type": "text/plain", //avoids preflight request
     },
-    referrerPolicy: "no-referrer-when-downgrade", // send the full referrer to the applause server, to have by default a clap per page 
     body: JSON.stringify(`${claps},${VERSION}`),
   })
     .then((response) => response.text())


### PR DESCRIPTION
Apologies, in the previous PR #122 I proposed to add a `referrerPolicy` option to the fetch call.

It seems great in theory but a number of browsers chose to ignore the `no-referrer-when-downgrade`for privacy reasons.
See this [article](https://blog.mozilla.org/security/2021/03/22/firefox-87-trims-http-referrers-by-default-to-protect-user-privacy/) for example.

As a result the referer received by the Applause server depends on the browser used and it messes with the clap count. It is probably best to revert that change for the moment